### PR TITLE
WIP: updates to the README for latest merged code

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ spec:
 
 - Wait several minutes and check the VolumeSnapshotBackup CR status for completed: 
 
+VolumeSnapshotBackup status:
+
+`oc get vsb -n <app-ns>`
+
+`oc get vsb <vsb-name> -n <app-ns> -ojsonpath="{.status.phase}"` 
+
+Alternatively one can use Velero / OADP status:
+
 `oc get backup`
 
 `oc get backup <name> -ojsonpath="{.status.phase}"`

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ allowVolumeExpansion: true
 
   
 ```
-$ cat << EOF > ./restic-secret.yaml
+cat << EOF > ./restic-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/README.md
+++ b/README.md
@@ -123,40 +123,6 @@ spec:
 ```
 
 
-- The OADP operator will install VolumeSnapshotMover CRDs `VolumeSnapshotBackup` and `VolumeSnapshotRestore` if `dataMover.enable`.
-  - Example CRs:
-
-
-```
-apiVersion: datamover.oadp.openshift.io/v1alpha1
-kind: VolumeSnapshotBackup
-metadata:
-  name: <vsb-name>
-spec:
-  volumeSnapshotContent:
-    name: <snapcontent-name>
-  protectedNamespace: <adp-namespace>
-  resticSecretRef: 
-    name: <restic-secret-name>
-```
-
-```
-apiVersion: datamover.oadp.openshift.io/v1alpha1
-kind: VolumeSnapshotRestore
-metadata:
-  name: <vsr-name>
-spec:
-  protectedNamespace: <protected-ns>
-  resticSecretRef: 
-    name: <restic-secret-name>
-  volumeSnapshotMoverBackupRef:
-    sourcePVCData: 
-      name: <source-pvc-name>
-      size: <source-pvc-size>
-    resticrepository: <your-restic-repo>
-    volumeSnapshotClassName: <vsclass-name>
-```
-
 <hr style="height:1px;border:none;color:#333;">
 
 <h4> For backup <a id="backup"></a></h4>
@@ -177,9 +143,9 @@ spec:
 
 - Wait several minutes and check the VolumeSnapshotBackup CR status for completed: 
 
-`oc get vsb -n <app-ns>`
+`oc get backup`
 
-`oc get vsb <vsb-name> -n <app-ns> -ojsonpath="{.status.phase}` 
+`oc get backup <name> -ojsonpath="{.status.phase}"`
 
 - There should now be a snapshot in the object store that was given in the restic secret.
 


### PR DESCRIPTION
0/  Going through this to get a better understanding of things.
1. There are a couple minor nits
2. There also may be some outdated instructions here, I'm not 100% so please check me.

In particular I was suspect of:
```
apiVersion: datamover.oadp.openshift.io/v1alpha1
kind: VolumeSnapshotRestore
metadata:
  name: <vsr-name>
spec:
  protectedNamespace: <protected-ns>
  resticSecretRef: 
    name: <restic-secret-name>
  volumeSnapshotMoverBackupRef:
    sourcePVCData: 
      name: <source-pvc-name>
      size: <source-pvc-size>
    resticrepository: <your-restic-repo>
    volumeSnapshotClassName: <vsclass-name>
```

I also think but am not sure about the `oc get vsb` commands.  I think those can be replaced w/ `oc get backup`