### PR TITLE
Respect docker platform by removing GOARCH from`go build`

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,7 +39,7 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{env.DOCKER_REGISTRY}}/${{env.DOCKER_REPOSITORY}}:${{github.sha}}-${{matrix.arch}}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=max,scope=${{matrix.arch}}
         platforms: linux/${{matrix.arch}}
     - name: Retag sha as ref_name and push built image
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
+DOCKER_BUILD_ARGS ?= --platform=linux/amd64
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build -t $(IMG) . $(DOCKER_BUILD_ARGS)
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
ie. Let docker platform decide what GOARCH should be.

If you are on arm64 and want to build image to run on amd64 node then specify during build [`--platform linux/amd64`](https://docs.docker.com/engine/reference/commandline/build/#options) in docker/podman build