### PR TITLE
Catch already exist create error on CreateOrUpdate

### DIFF
--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
@@ -65,7 +66,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorPVC(log logr.Logger) (bool, error
 
 		return r.buildPVCClone(pvcClone, &vsClone)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		r.Log.Info(fmt.Sprintf("err building pvc clone: %v", err))
 		return false, err
 	}
@@ -170,7 +171,7 @@ func (r *VolumeSnapshotBackupReconciler) BindPVCToDummyPod(log logr.Logger) (boo
 		return err
 	})
 
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		return false, err
 	}
 	if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {

--- a/controllers/replicationdestination.go
+++ b/controllers/replicationdestination.go
@@ -58,7 +58,8 @@ func (r *VolumeSnapshotRestoreReconciler) CreateReplicationDestination(log logr.
 
 		return r.buildReplicationDestination(repDestination, &vsr, &resticSecret)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
+		// don't error out if create errors due to replicationDestination already exists
 		return false, err
 	}
 

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -50,7 +50,8 @@ func (r *VolumeSnapshotBackupReconciler) CreateReplicationSource(log logr.Logger
 
 		return r.buildReplicationSource(repSource, &vsb, &clonedPVC)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
+		// don't error out if create errors due to replicationSource already exists
 		return false, err
 	}
 

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -85,7 +85,7 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 
 		return BuildResticSecret(&resticSecret, rsecret, resticrepo)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		return false, err
 	}
 
@@ -148,7 +148,7 @@ func (r *VolumeSnapshotRestoreReconciler) CreateVSRResticSecret(log logr.Logger)
 
 		return BuildResticSecret(&resticSecret, newResticSecret, resticrepo)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		return false, err
 	}
 

--- a/controllers/volumesnapshot.go
+++ b/controllers/volumesnapshot.go
@@ -54,7 +54,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshotContent(log logr.Lo
 		return r.buildVolumeSnapshotContentClone(vscClone, &vsb)
 	})
 
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		return false, err
 	}
 
@@ -114,7 +114,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshot(log logr.Logger) (
 
 		return r.buildVolumeSnapshotClone(vsClone, &vscClone)
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsAlreadyExists(err){
 		return false, err
 	}
 	if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {


### PR DESCRIPTION
test image `ghcr.io/kaovilai/volume-snapshot-mover:repDestAlreadyExists-amd64`

Hard to reproduce issue but could occur sometimes.