### PR TITLE
Cherry-pick #198: Pass custom CA configuration to restic replication source.

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -54,6 +54,7 @@ const (
 	GoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
 
 	// Restic repo vars
+	ResticCustomCA      = "RESTIC_CUSTOM_CA"
 	ResticPassword      = "RESTIC_PASSWORD"
 	ResticRepository    = "RESTIC_REPOSITORY"
 	ResticPruneInterval = "restic-prune-interval"
@@ -103,6 +104,7 @@ var (
 
 	GoogleApplicationCredentialsValue []byte
 
+	ResticCustomCAValue      []byte
 	ResticPasswordValue      []byte
 	ResticRepoValue          string
 	ResticPruneIntervalValue []byte
@@ -161,6 +163,8 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 				AWSDefaultRegionValue = val
 			case key == ResticPassword:
 				ResticPasswordValue = val
+			case key == ResticCustomCA:
+				ResticCustomCAValue = val
 			}
 		}
 
@@ -170,6 +174,7 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 				AWSAccessKey:        AWSAccessValue,
 				AWSSecretKey:        AWSSecretValue,
 				AWSDefaultRegion:    AWSDefaultRegionValue,
+				ResticCustomCA:      ResticCustomCAValue,
 				ResticPassword:      ResticPasswordValue,
 				ResticRepository:    []byte(resticrepo),
 				ResticPruneInterval: []byte(pruneInterval),
@@ -188,6 +193,8 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 				AzureAccountKeyValue = val
 			case key == ResticPassword:
 				ResticPasswordValue = val
+			case key == ResticCustomCA:
+				ResticCustomCAValue = val
 			}
 		}
 
@@ -196,6 +203,7 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 			Data: map[string][]byte{
 				AzureAccountName:    AzureAccountNameValue,
 				AzureAccountKey:     AzureAccountKeyValue,
+				ResticCustomCA:      ResticCustomCAValue,
 				ResticPassword:      ResticPasswordValue,
 				ResticRepository:    []byte(resticrepo),
 				ResticPruneInterval: []byte(pruneInterval),
@@ -212,6 +220,8 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 				GoogleApplicationCredentialsValue = val
 			case key == ResticPassword:
 				ResticPasswordValue = val
+			case key == ResticCustomCA:
+				ResticCustomCAValue = val
 			}
 		}
 
@@ -219,6 +229,7 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 		resticSecretData := &corev1.Secret{
 			Data: map[string][]byte{
 				GoogleApplicationCredentials: GoogleApplicationCredentialsValue,
+				ResticCustomCA:               ResticCustomCAValue,
 				ResticPassword:               ResticPasswordValue,
 				ResticRepository:             []byte(resticrepo),
 				ResticPruneInterval:          []byte(pruneInterval),

--- a/controllers/replicationdestination.go
+++ b/controllers/replicationdestination.go
@@ -120,6 +120,13 @@ func (r *VolumeSnapshotRestoreReconciler) buildReplicationDestination(replicatio
 		replicationDestination.Spec = replicationDestinationSpec
 	}
 
+	// include custom CA if specified
+	resticCustomCA := resticSecret.Data[ResticCustomCA]
+	if len(resticCustomCA) > 0 {
+		replicationDestination.Spec.Restic.CustomCA.SecretName = resticSecret.Name
+		replicationDestination.Spec.Restic.CustomCA.Key = ResticCustomCA
+	}
+
 	return nil
 }
 

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -138,6 +138,13 @@ func (r *VolumeSnapshotBackupReconciler) buildReplicationSource(replicationSourc
 		replicationSource.Spec = replicationSourceSpec
 	}
 
+	// pass along a custom CA if specified
+	resticCustomCA := resticSecret.Data[ResticCustomCA]
+	if len(resticCustomCA) > 0 {
+		replicationSource.Spec.Restic.CustomCA.SecretName = resticSecret.Name
+		replicationSource.Spec.Restic.CustomCA.Key = ResticCustomCA
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry-pick of #198: [OADP-639](https://issues.redhat.com//browse/OADP-639): Pass custom CA configuration to restic replication source.