### PR TITLE
OADP-1151: Skip Deletion of ReplicationSource CRs

### DIFF
--- a/controllers/cleanup.go
+++ b/controllers/cleanup.go
@@ -20,7 +20,6 @@ var cleanupVSBTypes = []client.Object{
 	&snapv1.VolumeSnapshot{},
 	&snapv1.VolumeSnapshotContent{},
 	&corev1.Secret{},
-	&volsyncv1alpha1.ReplicationSource{},
 }
 
 var cleanupVSRTypes = []client.Object{

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -153,6 +153,12 @@ func (r *VolumeSnapshotBackupReconciler) BindPVCToDummyPod(log logr.Logger) (boo
 		return false, err
 	}
 
+	// no need to perform BindPVCToDummyPod step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping BindPVCToDummyPod step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// fetch the cloned PVC
 	clonedPVC := corev1.PersistentVolumeClaim{}
 	err := r.Get(r.Context,
@@ -304,6 +310,12 @@ func (r *VolumeSnapshotBackupReconciler) IsPVCBound(log logr.Logger) (bool, erro
 		}
 		r.Log.Error(err, fmt.Sprintf("unable to fetch volumesnapshotbackup %s", r.req.NamespacedName))
 		return false, err
+	}
+
+	// no need to perform IsPVCBound step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping IsPVCBound step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
 	}
 
 	// get cloned pvc

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -30,6 +30,12 @@ func (r *VolumeSnapshotBackupReconciler) CreateReplicationSource(log logr.Logger
 		return false, err
 	}
 
+	// no need to create rs for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping create rs step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// get cloned pvc
 	pvcName := fmt.Sprintf("%s-pvc", vsb.Spec.VolumeSnapshotContent.Name)
 	clonedPVC := corev1.PersistentVolumeClaim{}

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -36,6 +36,12 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 		return false, err
 	}
 
+	// no need to perform CreateVSBResticSecret step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping CreateVSBResticSecret step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// get cloned pvc
 	pvcName := fmt.Sprintf("%s-pvc", vsb.Spec.VolumeSnapshotContent.Name)
 	pvc := corev1.PersistentVolumeClaim{}

--- a/controllers/volumesnapshot.go
+++ b/controllers/volumesnapshot.go
@@ -30,6 +30,12 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshotContent(log logr.Lo
 		return false, err
 	}
 
+	// no need to perform MirrorVolumeSnapshotContent step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping MirrorVolumeSnapshotContent step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// fetch original vsc
 	vscInCluster := snapv1.VolumeSnapshotContent{}
 	if err := r.Get(r.Context, types.NamespacedName{Name: vsb.Spec.VolumeSnapshotContent.Name}, &vscInCluster); err != nil {
@@ -90,6 +96,12 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshot(log logr.Logger) (
 		}
 		r.Log.Error(err, fmt.Sprintf("unable to fetch volumesnapshotbackup %s", r.req.NamespacedName))
 		return false, err
+	}
+
+	// no need to perform MirrorVolumeSnapshot step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping MirrorVolumeSnapshot step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
 	}
 
 	// fetch vsc clone
@@ -208,6 +220,12 @@ func (r *VolumeSnapshotBackupReconciler) WaitForClonedVolumeSnapshotToBeReady(lo
 		return false, err
 	}
 
+	// no need to perform WaitForClonedVolumeSnapshotToBeReady step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping WaitForClonedVolumeSnapshotToBeReady step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// Get the clone VSC
 	vscClone := snapv1.VolumeSnapshotContent{}
 	vscCloneName := fmt.Sprintf("%s-clone", vsb.Spec.VolumeSnapshotContent.Name)
@@ -242,6 +260,12 @@ func (r *VolumeSnapshotBackupReconciler) WaitForClonedVolumeSnapshotContentToBeR
 		}
 		r.Log.Error(err, fmt.Sprintf("unable to fetch volumesnapshotbackup %s", r.req.NamespacedName))
 		return false, err
+	}
+
+	// no need to perform WaitForClonedVolumeSnapshotContentToBeReady step for the vsb if the datamovement has already completed
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping WaitForClonedVolumeSnapshotContentToBeReady step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
 	}
 
 	// fetch vsc clone


### PR DESCRIPTION
Images you can use for testing:
```
dataMoverImageFqin: 'quay.io/spampatt/volume-snapshot-mover:keep-rs'
vsmPluginImageFqin: 'quay.io/spampatt/velero-plugin-for-vsm:dia-rs'
```

Related plugin PR: https://github.com/migtools/velero-plugin-for-vsm/pull/16