### PR TITLE
Update restic boolean doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ spec:
         provider: aws
   configuration:
     restic:
-      enable: false
+      enable: false #[true, false]
     velero:
       defaultPlugins:
         - openshift


### PR DESCRIPTION
Ensure that docs, customers, qe etc do not get the impression that restic must be turned off for vsm and datamover to be enabled.