### PR TITLE
Fix VSB phase update loop

### DIFF
--- a/controllers/cleanup.go
+++ b/controllers/cleanup.go
@@ -44,6 +44,12 @@ func (r *VolumeSnapshotBackupReconciler) CleanBackupResources(log logr.Logger) (
 		return false, nil
 	}
 
+	// no need to perfrom cleanup for the vsb if the datamovement has already completed, completed phase comes after cleanup
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
+		r.Log.Info(fmt.Sprintf("skipping CleanBackupResources step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
+		return true, nil
+	}
+
 	// get resources with VSB controller label in protected ns
 	deleteOptions := []client.DeleteAllOfOption{
 		client.MatchingLabels{VSBLabel: vsb.Name},

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -383,7 +383,7 @@ func (r *VolumeSnapshotBackupReconciler) setVSBStatus(log logr.Logger) (bool, er
 
 	if repSource.Status != nil {
 
-		if len(vsb.Status.Phase) > 0 {
+		if len(vsb.Status.Phase) > 0 && vsb.Status.Phase != volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 			// no need to check replicationSource progess if completed
 			if vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
 				return true, nil

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -29,7 +29,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorPVC(log logr.Logger) (bool, error
 	}
 
 	// no need to mirror pvc for the vsb if the datamovement has already completed, no need to fetch source VS as it will be deleted once backup completes
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping mirror pvc step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -154,7 +154,7 @@ func (r *VolumeSnapshotBackupReconciler) BindPVCToDummyPod(log logr.Logger) (boo
 	}
 
 	// no need to perform BindPVCToDummyPod step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping BindPVCToDummyPod step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -313,7 +313,7 @@ func (r *VolumeSnapshotBackupReconciler) IsPVCBound(log logr.Logger) (bool, erro
 	}
 
 	// no need to perform IsPVCBound step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping IsPVCBound step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -31,7 +31,7 @@ func (r *VolumeSnapshotBackupReconciler) CreateReplicationSource(log logr.Logger
 	}
 
 	// no need to create rs for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping create rs step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -187,7 +187,7 @@ func (r *VolumeSnapshotBackupReconciler) setStatusFromRepSource(vsb *volsnapmove
 		}
 	}
 
-	if repSourceCompleted && reconConditionCompleted.Type == volsyncv1alpha1.ConditionSynchronizing {
+	if repSourceCompleted && reconConditionCompleted.Type == volsyncv1alpha1.ConditionSynchronizing && vsb.Status.Phase != volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 
 		// Update VSB status as volsync completed
 		vsb.Status.Phase = volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -37,7 +37,7 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 	}
 
 	// no need to perform CreateVSBResticSecret step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping CreateVSBResticSecret step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}

--- a/controllers/volumesnapshot.go
+++ b/controllers/volumesnapshot.go
@@ -31,7 +31,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshotContent(log logr.Lo
 	}
 
 	// no need to perform MirrorVolumeSnapshotContent step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping MirrorVolumeSnapshotContent step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -99,7 +99,7 @@ func (r *VolumeSnapshotBackupReconciler) MirrorVolumeSnapshot(log logr.Logger) (
 	}
 
 	// no need to perform MirrorVolumeSnapshot step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping MirrorVolumeSnapshot step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -221,7 +221,7 @@ func (r *VolumeSnapshotBackupReconciler) WaitForClonedVolumeSnapshotToBeReady(lo
 	}
 
 	// no need to perform WaitForClonedVolumeSnapshotToBeReady step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping WaitForClonedVolumeSnapshotToBeReady step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}
@@ -263,7 +263,7 @@ func (r *VolumeSnapshotBackupReconciler) WaitForClonedVolumeSnapshotContentToBeR
 	}
 
 	// no need to perform WaitForClonedVolumeSnapshotContentToBeReady step for the vsb if the datamovement has already completed
-	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverVolSyncPhaseCompleted {
+	if len(vsb.Status.Phase) > 0 && vsb.Status.Phase == volsnapmoverv1alpha1.SnapMoverBackupPhaseCompleted {
 		r.Log.Info(fmt.Sprintf("skipping WaitForClonedVolumeSnapshotContentToBeReady step for vsb %s/%s as datamovement is complete", vsb.Namespace, vsb.Name))
 		return true, nil
 	}


### PR DESCRIPTION
Due to the current change in OADP 1.2 regarding not cleaning up the ReplicationSource CRs from cluster the phase VSB phase update needed some fixes. This PR makes those fixes. Basically what was happening due to the code which cascades status from ReplicationSource to VSB, the VSB phase was looping between `cleanup -> completed -> snapshotbackupDone`, this PR breaks the loop if the vsb is in complete state and fixes the phase cascade code. Also, skips steps from reconcile batch if the vsb is in complete state.

`dataMoverImageFqin: 'quay.io/spampatt/volume-snapshot-mover:fix-phase-loop'`