### PR TITLE
OADP-2175: Make use of restic secret to pass datamover retain policy instead of datamover config map

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -146,7 +146,7 @@ func PopulateResticSecret(name string, namespace string, label string) (*corev1.
 	return newResticSecret, nil
 }
 
-func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, resticrepo, pruneInterval string) error {
+func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, resticrepo, pruneInterval string, rpolicy *RetainPolicy) error {
 	if givensecret == nil {
 		return errors.New("nil givensecret in BuildResticSecret")
 	}
@@ -177,13 +177,19 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 		// build new Restic secret
 		resticSecretData := &corev1.Secret{
 			Data: map[string][]byte{
-				AWSAccessKey:        AWSAccessValue,
-				AWSSecretKey:        AWSSecretValue,
-				AWSDefaultRegion:    AWSDefaultRegionValue,
-				ResticCustomCA:      ResticCustomCAValue,
-				ResticPassword:      ResticPasswordValue,
-				ResticRepository:    []byte(resticrepo),
-				ResticPruneInterval: []byte(pruneInterval),
+				AWSAccessKey:                AWSAccessValue,
+				AWSSecretKey:                AWSSecretValue,
+				AWSDefaultRegion:            AWSDefaultRegionValue,
+				ResticCustomCA:              ResticCustomCAValue,
+				ResticPassword:              ResticPasswordValue,
+				ResticRepository:            []byte(resticrepo),
+				ResticPruneInterval:         []byte(pruneInterval),
+				SnapshotRetainPolicyDaily:   []byte(rpolicy.daily),
+				SnapshotRetainPolicyWeekly:  []byte(rpolicy.weekly),
+				SnapshotRetainPolicyHourly:  []byte(rpolicy.hourly),
+				SnapshotRetainPolicyMonthly: []byte(rpolicy.monthly),
+				SnapshotRetainPolicyYearly:  []byte(rpolicy.yearly),
+				SnapshotRetainPolicyWithin:  []byte(rpolicy.within),
 			},
 		}
 		secret.Data = resticSecretData.Data
@@ -207,12 +213,18 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 		// build new Restic secret
 		resticSecretData := &corev1.Secret{
 			Data: map[string][]byte{
-				AzureAccountName:    AzureAccountNameValue,
-				AzureAccountKey:     AzureAccountKeyValue,
-				ResticCustomCA:      ResticCustomCAValue,
-				ResticPassword:      ResticPasswordValue,
-				ResticRepository:    []byte(resticrepo),
-				ResticPruneInterval: []byte(pruneInterval),
+				AzureAccountName:            AzureAccountNameValue,
+				AzureAccountKey:             AzureAccountKeyValue,
+				ResticCustomCA:              ResticCustomCAValue,
+				ResticPassword:              ResticPasswordValue,
+				ResticRepository:            []byte(resticrepo),
+				ResticPruneInterval:         []byte(pruneInterval),
+				SnapshotRetainPolicyDaily:   []byte(rpolicy.daily),
+				SnapshotRetainPolicyWeekly:  []byte(rpolicy.weekly),
+				SnapshotRetainPolicyHourly:  []byte(rpolicy.hourly),
+				SnapshotRetainPolicyMonthly: []byte(rpolicy.monthly),
+				SnapshotRetainPolicyYearly:  []byte(rpolicy.yearly),
+				SnapshotRetainPolicyWithin:  []byte(rpolicy.within),
 			},
 		}
 		secret.Data = resticSecretData.Data
@@ -239,6 +251,12 @@ func BuildResticSecret(givensecret *corev1.Secret, secret *corev1.Secret, restic
 				ResticPassword:               ResticPasswordValue,
 				ResticRepository:             []byte(resticrepo),
 				ResticPruneInterval:          []byte(pruneInterval),
+				SnapshotRetainPolicyDaily:    []byte(rpolicy.daily),
+				SnapshotRetainPolicyWeekly:   []byte(rpolicy.weekly),
+				SnapshotRetainPolicyHourly:   []byte(rpolicy.hourly),
+				SnapshotRetainPolicyMonthly:  []byte(rpolicy.monthly),
+				SnapshotRetainPolicyYearly:   []byte(rpolicy.yearly),
+				SnapshotRetainPolicyWithin:   []byte(rpolicy.within),
 			},
 		}
 		secret.Data = resticSecretData.Data

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -135,7 +135,7 @@ func Test_BuildResticSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := BuildResticSecret(tt.givensecret, tt.secret, "repo", "14")
+			err := BuildResticSecret(tt.givensecret, tt.secret, "repo", "14", &RetainPolicy{})
 			if err != nil && tt.wantErr {
 				t.Logf("BuildResticSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -127,7 +127,17 @@ func (r *VolumeSnapshotBackupReconciler) buildReplicationSource(replicationSourc
 		}
 	}
 
-	resticVolOptions, err := r.configureRepSourceResticVolOptions(vsb, resticSecret.Name, pvc, cm, sa)
+	// fetch the retain policy from restic secret and then pass it on to replication source CR
+	// modify the configureRepSourceResticVolOptions function to
+	rpolicy := RetainPolicy{}
+	rpolicy.hourly = string(resticSecret.Data[SnapshotRetainPolicyHourly])
+	rpolicy.monthly = string(resticSecret.Data[SnapshotRetainPolicyMonthly])
+	rpolicy.daily = string(resticSecret.Data[SnapshotRetainPolicyDaily])
+	rpolicy.weekly = string(resticSecret.Data[SnapshotRetainPolicyWeekly])
+	rpolicy.yearly = string(resticSecret.Data[SnapshotRetainPolicyYearly])
+	rpolicy.within = string(resticSecret.Data[SnapshotRetainPolicyWithin])
+
+	resticVolOptions, err := r.configureRepSourceResticVolOptions(vsb, resticSecret.Name, pvc, cm, sa, rpolicy)
 	if err != nil {
 		return err
 	}
@@ -315,78 +325,45 @@ func (r *VolumeSnapshotBackupReconciler) configureRepSourceVolOptions(vsb *volsn
 	return &repSrcVolOptions, nil
 }
 
-func (r *VolumeSnapshotBackupReconciler) configureRepSourceSnapshotRetainPolicy(cm *corev1.ConfigMap) (*volsyncv1alpha1.ResticRetainPolicy, error) {
-
-	var snapshotRetainPolicyDaily, snapshotRetainPolicyHourly, snapshotRetainPolicyWeekly, snapshotRetainPolicyMonthly, snapshotRetainPolicyYearly, snapshotRetainPolicyWithin string
+func (r *VolumeSnapshotBackupReconciler) configureRepSourceSnapshotRetainPolicy(rpolicy RetainPolicy) (*volsyncv1alpha1.ResticRetainPolicy, error) {
+	// check for retain policy params in restic secret data
 	var daily, hourly, weekly, monthly, yearly = int64(0), int64(0), int64(0), int64(0), int64(0)
 	var err error
 	retainPolicy := volsyncv1alpha1.ResticRetainPolicy{}
-	// if datamover configmap has data, use these values
-	if cm != nil && cm.Data != nil {
-		for spec := range cm.Data {
-
-			// check for SnapshotRetainPolicy parameters and assign the values accordingly to the volsync restic retain struct
-
-			if spec == SnapshotRetainPolicyDaily {
-				snapshotRetainPolicyDaily = cm.Data[SnapshotRetainPolicyDaily]
-			}
-
-			if spec == SnapshotRetainPolicyHourly {
-				snapshotRetainPolicyHourly = cm.Data[SnapshotRetainPolicyHourly]
-			}
-
-			if spec == SnapshotRetainPolicyWeekly {
-				snapshotRetainPolicyWeekly = cm.Data[SnapshotRetainPolicyWeekly]
-			}
-
-			if spec == SnapshotRetainPolicyMonthly {
-				snapshotRetainPolicyMonthly = cm.Data[SnapshotRetainPolicyMonthly]
-			}
-
-			if spec == SnapshotRetainPolicyYearly {
-				snapshotRetainPolicyYearly = cm.Data[SnapshotRetainPolicyYearly]
-			}
-
-			if spec == SnapshotRetainPolicyWithin {
-				snapshotRetainPolicyWithin = cm.Data[SnapshotRetainPolicyWithin]
-			}
-
-		}
-	}
-
-	if len(snapshotRetainPolicyDaily) > 0 {
-		daily, err = strconv.ParseInt(snapshotRetainPolicyDaily, 10, 32)
+	// if datamover retainpolicy has data, use these values
+	if len(rpolicy.daily) > 0 {
+		daily, err = strconv.ParseInt(rpolicy.daily, 10, 32)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(snapshotRetainPolicyHourly) > 0 {
-		hourly, err = strconv.ParseInt(snapshotRetainPolicyHourly, 10, 32)
+	if len(rpolicy.hourly) > 0 {
+		hourly, err = strconv.ParseInt(rpolicy.hourly, 10, 32)
 
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(snapshotRetainPolicyWeekly) > 0 {
-		weekly, err = strconv.ParseInt(snapshotRetainPolicyWeekly, 10, 32)
+	if len(rpolicy.weekly) > 0 {
+		weekly, err = strconv.ParseInt(rpolicy.weekly, 10, 32)
 
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(snapshotRetainPolicyMonthly) > 0 {
-		monthly, err = strconv.ParseInt(snapshotRetainPolicyMonthly, 10, 32)
+	if len(rpolicy.monthly) > 0 {
+		monthly, err = strconv.ParseInt(rpolicy.monthly, 10, 32)
 
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(snapshotRetainPolicyYearly) > 0 {
-		yearly, err = strconv.ParseInt(snapshotRetainPolicyYearly, 10, 32)
+	if len(rpolicy.yearly) > 0 {
+		yearly, err = strconv.ParseInt(rpolicy.yearly, 10, 32)
 
 		if err != nil {
 			return nil, err
@@ -413,15 +390,15 @@ func (r *VolumeSnapshotBackupReconciler) configureRepSourceSnapshotRetainPolicy(
 		retainPolicy.Yearly = pointer.Int32(int32(yearly))
 	}
 
-	if len(snapshotRetainPolicyWithin) > 0 {
-		retainPolicy.Within = &snapshotRetainPolicyWithin
+	if len(rpolicy.within) > 0 {
+		retainPolicy.Within = &rpolicy.within
 	}
 
 	return &retainPolicy, nil
 }
 
 func (r *VolumeSnapshotBackupReconciler) configureRepSourceResticVolOptions(vsb *volsnapmoverv1alpha1.VolumeSnapshotBackup, resticSecretName string,
-	pvc *corev1.PersistentVolumeClaim, cm *corev1.ConfigMap, sa *corev1.ServiceAccount) (*volsyncv1alpha1.ReplicationSourceResticSpec, error) {
+	pvc *corev1.PersistentVolumeClaim, cm *corev1.ConfigMap, sa *corev1.ServiceAccount, rpolicy RetainPolicy) (*volsyncv1alpha1.ReplicationSourceResticSpec, error) {
 
 	if vsb == nil {
 		return nil, errors.New("nil vsr in configureRepSourceResticVolOptions")
@@ -487,7 +464,7 @@ func (r *VolumeSnapshotBackupReconciler) configureRepSourceResticVolOptions(vsb 
 		return nil, err
 	}
 
-	retainPolicySpec, err := r.configureRepSourceSnapshotRetainPolicy(cm)
+	retainPolicySpec, err := r.configureRepSourceSnapshotRetainPolicy(rpolicy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Related to https://github.com/openshift/oadp-operator/pull/1078