### PR TITLE
fix: OADP-2066 Add backup name to folder structure of Datamover backup

### DIFF
--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -114,7 +114,7 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 	}
 
 	// TODO should check if label is present first? or it is always present?
-	resticrepo := fmt.Sprintf("%s/%s/%s/%s", ResticRepoValue, vsb.Labels["velero.io/backup-name"], pvc.Namespace, pvc.Name)
+	resticrepo := fmt.Sprintf("%s/%s/%s/%s", ResticRepoValue, pvc.Namespace, vsb.Labels["velero.io/backup-name"], pvc.Name)
 
 	rsecret, err := PopulateResticSecret(vsb.Name, vsb.Spec.ProtectedNamespace, VSBLabel)
 	if err != nil {

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -113,7 +113,6 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 		}
 	}
 
-	// TODO should check if label is present first? or it is always present?
 	resticrepo := fmt.Sprintf("%s/%s/%s/%s", ResticRepoValue, pvc.Namespace, vsb.Labels["velero.io/backup-name"], pvc.Name)
 
 	rsecret, err := PopulateResticSecret(vsb.Name, vsb.Spec.ProtectedNamespace, VSBLabel)

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -82,40 +82,39 @@ func (r *VolumeSnapshotBackupReconciler) CreateVSBResticSecret(log logr.Logger) 
 	var scheduleCronExpr = ""
 	rpolicy := RetainPolicy{}
 	for key, val := range resticSecret.Data {
+		stringVal := string(val)
 		if key == ResticRepository {
 			// if trailing '/' in user-created Restic repo, remove it
-			stringVal := string(val)
-			stringVal = strings.TrimRight(stringVal, "/")
-
-			ResticRepoValue = stringVal
+			ResticRepoValue = strings.TrimRight(stringVal, "/")
 		}
 		if key == ResticPruneInterval {
-			pruneInterval = string(val)
+			pruneInterval = stringVal
 		}
 		if key == SnapshotScheduleCron {
-			scheduleCronExpr = string(val)
+			scheduleCronExpr = stringVal
 		}
 		if key == SnapshotRetainPolicyMonthly {
-			rpolicy.monthly = string(val)
+			rpolicy.monthly = stringVal
 		}
 		if key == SnapshotRetainPolicyDaily {
-			rpolicy.daily = string(val)
+			rpolicy.daily = stringVal
 		}
 		if key == SnapshotRetainPolicyHourly {
-			rpolicy.hourly = string(val)
+			rpolicy.hourly = stringVal
 		}
 		if key == SnapshotRetainPolicyWeekly {
-			rpolicy.weekly = string(val)
+			rpolicy.weekly = stringVal
 		}
 		if key == SnapshotRetainPolicyYearly {
-			rpolicy.yearly = string(val)
+			rpolicy.yearly = stringVal
 		}
 		if key == SnapshotRetainPolicyWithin {
-			rpolicy.within = string(val)
+			rpolicy.within = stringVal
 		}
 	}
 
-	resticrepo := fmt.Sprintf("%s/%s/%s", ResticRepoValue, pvc.Namespace, pvc.Name)
+	// TODO should check if label is present first? or it is always present?
+	resticrepo := fmt.Sprintf("%s/%s/%s/%s", ResticRepoValue, vsb.Labels["velero.io/backup-name"], pvc.Namespace, pvc.Name)
 
 	rsecret, err := PopulateResticSecret(vsb.Name, vsb.Spec.ProtectedNamespace, VSBLabel)
 	if err != nil {


### PR DESCRIPTION
## Description

When creating a Datamover backup, files are organized in the following structure:
```
├── bucketName
│   └── OADPNameSpace
│        └── VSCName-pvc
│            └──files
```
This PRs adds on more level with the backup name:
```
├── bucketName
│   └── OADPNameSpace
│       └── BackupName
│           └── VSCName-pvc
│                └──files
```

Examples before and after in IBM
![Screenshot from 2023-07-12 15-37-41](https://github.com/migtools/volume-snapshot-mover/assets/66965232/3804c8a6-f85d-48d8-b39c-00cb7e6d77a0)
![Screenshot from 2023-07-13 14-39-38](https://github.com/migtools/volume-snapshot-mover/assets/66965232/d62e0b13-84c2-4d03-beda-1ea19e8d97ef)


## Related issues

Fixes https://github.com/migtools/volume-snapshot-mover/issues/234

## How to test

Install VolSync `stable-0.7` and OADP `stable-1.2` operators from OperatorHub.

Create Velero and DataMover credentials secrets.

Use VolumeSnapshotMover (controller) image created for this PR (it was generated running `docker image build --tag quay.io/msouzaol/volume-snapshot-mover:pr254-2 -f Dockerfile.ubi .`) in OADP DPA. Ex.:
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: oadp-vsm-example
  namespace: openshift-adp
spec:
  backupLocations:
    - velero:
        backupSyncPeriod: 2m0s
        config:
          profile: default
          region: <region>
          s3ForcePathStyle: 'true'
          s3Url: <URL>
        credential:
          key: cloud
          name: cloud-credentials
        default: true
        objectStorage:
          bucket: <name>
          prefix: velero
        provider: aws
  configuration:
    restic:
      enable: false
    velero:
      defaultPlugins:
        - openshift
        - aws
        - csi
        - vsm
      featureFlags:
        - EnableCSI
  features:
    dataMover:
      credentialName: dm-credentials
      enable: true
      maxConcurrentBackupVolumes: '2'
  unsupportedOverrides:
    dataMoverImageFqin: 'quay.io/msouzaol/volume-snapshot-mover:pr254-2'
```

Run backups in a application (I suggest using one from bookbag). Example for `mysql-persistent`
```sh
# Normal
velero backup create --include-namespaces mysql-persistent
# Schedule
velero schedule create example-schedule --schedule="0 3 * * *" --include-namespaces mysql-persistent
velero backup create --from-schedule example-schedule
```